### PR TITLE
feat: add support for custom kms hosts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "phase_dev"
-version = "1.0.0"
+version = "1.1.0"
 description = "Python SDK for Phase"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/phase/utils/crypto.py
+++ b/src/phase/utils/crypto.py
@@ -6,9 +6,6 @@ from nacl.bindings import crypto_kx_keypair, crypto_aead_xchacha20poly1305_ietf_
 from ..version import __version__
 
 
-PHASE_KMS_URI = "https://kms.phase.dev/"
-
-
 def xor_bytes(a, b) -> bytes:
     """
     Computes the XOR of two byte arrays byte by byte.
@@ -129,7 +126,7 @@ def decrypt_b64(ct, key) -> bytes:
     return plaintext_bytes.decode('utf-8')
 
 
-def fetch_app_key(appToken, wrapKey, appId, dataSize) -> str:
+def fetch_app_key(appToken, wrapKey, appId, dataSize, host) -> str:
     """
     Fetches the application key share from Phase KMS.
 
@@ -152,7 +149,7 @@ def fetch_app_key(appToken, wrapKey, appId, dataSize) -> str:
         "PhSize": f"{dataSize}"
     }
 
-    response = requests.get(f"{PHASE_KMS_URI}{appId}", headers=headers)
+    response = requests.get(f"{host}/{appId}", headers=headers)
 
     if response.status_code == 404:
         raise Exception("Invalid app token")

--- a/src/phase/version.py
+++ b/src/phase/version.py
@@ -1,2 +1,2 @@
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __ph_version__ = "v1"

--- a/tests/test_decrypt.py
+++ b/tests/test_decrypt.py
@@ -11,7 +11,7 @@ def phase_instance():
     return Phase(APP_ID, APP_SECRET)
 
 
-def mock_fetch_app_key(appToken, wrapKey, appId, dataSize):
+def mock_fetch_app_key(appToken, wrapKey, appId, dataSize, custom_kms_host=None):
     return "e35ae9560207c90fa3dd68a8715e13a1ef988bffa284db73f04328df17f37cfe"
 
 


### PR DESCRIPTION
## Description

Adds support for using the SDK with a custom kms host. The client can now be initialized with an optional host argument provided to the constructor:

```python
phase = Phase(APP_ID, APP_SECRET, KMS_HOST)
```

## Changes

* Added `_kms_host` as a class variable
* Updated the Phase class constructor to accept an optional `custom_kms_host` argument
* Set the `_kms_host` to the provided custom host if available, else use the default kms host
* Updated the `fetch_app_key` function to accept the kms host as an argument
* Updated tests
* Bumped version to `1.1.0`